### PR TITLE
FastAPI + WebSockets implementation

### DIFF
--- a/.do/app.yml
+++ b/.do/app.yml
@@ -21,8 +21,7 @@ services:
       timeout_seconds: 30
       port: 11844
       initial_delay_seconds: 10
-    http_port: 11845
-    internal_ports: [11844]
+    http_port: 9000
     instance_count: 1
     instance_size_slug: basic-xxs
     name: snakem-server

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,7 @@
         "--port",
         "9000",
         "--log-level",
-        "info"
+        "debug"
       ],
       "jinja": false,
       "justMyCode": false

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,8 +4,18 @@
       "name": "snakem server (local)",
       "type": "python",
       "request": "launch",
-      "module": "snakem.net.server",
-      "justMyCode": true
+      "module": "uvicorn",
+      "args": [
+        "snakem.web.app:app",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        "9000",
+        "--log-level",
+        "info"
+      ],
+      "jinja": false,
+      "justMyCode": false
     },
     {
       "name": "snakem client (local)",

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,4 +22,4 @@ USER appuser
 EXPOSE 9000/tcp
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ["uvicorn", "snakem.net.server:app", "--host", "0.0.0.0", "--port", "9000", "--log-level", "info"]
+CMD ["uvicorn", "snakem.web.app:app", "--host", "0.0.0.0", "--port", "9000", "--log-level", "info"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,7 @@ COPY . /app
 RUN adduser -u 5678 --disabled-password --gecos "" appuser && chown -R appuser /app
 USER appuser
 
-EXPOSE 11844/tcp
-EXPOSE 11845/udp
+EXPOSE 9000/tcp
 
 # During debugging, this entry point will be overridden. For more information, please refer to https://aka.ms/vscode-docker-python-debug
-CMD ["python", "-m", "snakem.net.server"]
+CMD ["uvicorn", "snakem.net.server:app", "--host", "0.0.0.0", "--port", "9000", "--log-level", "info"]

--- a/README.md
+++ b/README.md
@@ -22,20 +22,30 @@ License: GPLv3 (see LICENSE.md file)
 - Python 3.11 or later
 - Docker CLI
 
-### Starting the game:
+### Starting the server (local):
+
+1. Open a terminal and navigate to the source root folder.
+2. Run `$ python3 -m venv .venv` to create the virtual Python environment.
+3. Run `$ source .venv/bin/activate` to enter the virtual environment.
+4. Run `$ pip install -r requirements.txt` to install all dependencies in the virtual environment.
+5. Run `$ uvicorn snakem.net.server:app --host 127.0.0.1 --port 9000 --log-level info` to start the server.
+
+### Starting the server (Docker):
 
 1. Open a terminal and navigate to the source root folder.
 2. Run `$ sudo docker build -t snakem-dev:latest .` to build the Docker image.
-3. Run `sudo docker run -d -p 11845:11845/udp --name snakem-dev snakem-dev:latest` to create the Docker container and start the server.
-4. Run `sudo docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' snakem-dev` to get the IP address of the container.
+3. Run `$ sudo docker run -d -p 9000:9000/tcp --name snakem-dev snakem-dev:latest` to create the Docker container and start the server.
+4. Run `$ sudo docker inspect -f '{{range.NetworkSettings.Networks}}{{.IPAddress}}{{end}}' snakem-dev` to get the IP address of the container.
 5. Update SERVER_HOST in `snakem/config/client.py` with the container IP address.
-6. Run `$ python3 -m snakem.net.client` to start the client.
 
-### Debugging the game:
+### Starting the client:
+
+1. Run `$ python3 -m snakem.net.client` to start the client.
+
+### Debugging:
 
 1. Install VS Code and the recommended extensions (see `.vscode/extensions.json`).
 2. In the Run and Debug view, launch **snakem server** or **snakem client**.
-3. Start the server or client as described in #starting-the-game.
 
 ### Deploy your own server:
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ License: GPLv3 (see LICENSE.md file)
 2. Run `$ python3 -m venv .venv` to create the virtual Python environment.
 3. Run `$ source .venv/bin/activate` to enter the virtual environment.
 4. Run `$ pip install -r requirements.txt` to install all dependencies in the virtual environment.
-5. Run `$ uvicorn snakem.net.server:app --host 127.0.0.1 --port 9000 --log-level info` to start the server.
+5. Run `$ uvicorn snakem.web.app:app --host 127.0.0.1 --port 9000 --log-level debug --reload` to start the server.
 
 ### Starting the server (Docker):
 

--- a/TODO.md
+++ b/TODO.md
@@ -35,5 +35,36 @@
   https://packaging.python.org/en/latest/
 
 - do we need to watch for desync between the game tick counter and the time elapsed?
+
   - we changed from static step counter to real timekeeper
   - need to add a prioritization system that drops old net messages or advances game ticks to catch up (e.g. if a game update has been seen, we only want to apply updates from that point)
+
+- use async queue
+  https://docs.python.org/3/library/asyncio-queue.html
+
+- review these and make some unit tests for client/server messaging
+  \# NOTE: This second example does not work because TestClient manages its own event loop.
+  \# See: https://www.starlette.io/testclient/#asynchronous-tests
+
+  \# async def main() -> None:
+  \# client = TestClient(app)
+
+  \# response = client.get("/api/health")
+
+  \# assert response.status_code == 200
+  \# assert response.json() == {"status": "alive"}
+
+  \# with client.websocket_connect('/ws') as ws:
+  \# await Client(ws, scr, config.STEP_TIME_MS, config.KEYS).start()
+
+  \# async def main() -> None:
+  \# async with AsyncClient(app=app, base_url=f'ws://{config.SERVER_HOST}:{config.SERVER_PORT}') as client:
+  \# response = await client.get("/api/health")
+
+  \# assert response.status_code == 200
+  \# assert response.json() == {"status": "alive"}
+  \# client.send()
+  \# #with client.websocket_connect('/ws') as ws:
+  \# # await Client(ws, scr, config.STEP_TIME_MS, config.KEYS).start()
+
+- fix server debug launch

--- a/TODO.md
+++ b/TODO.md
@@ -68,3 +68,15 @@
   \# # await Client(ws, scr, config.STEP_TIME_MS, config.KEYS).start()
 
 - fix server debug launch
+
+- client/server should only sleep long enough to advance the game when in game mode
+
+- client/server should sync on real time and not just game tick
+
+- client/server should maybe also use game instance ID in case game start/end messages get lost?
+
+  - how does websockets handle lost messages?
+
+- it appears to be possible to join a running game, and late players dont get assigned to a snake; might break something
+
+- add venv as build-time requirement

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 # To ensure app dependencies are ported from your virtual environment/host machine into your container, run 'pip freeze > requirements.txt' in the terminal to overwrite this file
+
+aioconsole
+fastapi
+uvicorn[standard]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 # To ensure app dependencies are ported from your virtual environment/host machine into your container, run 'pip freeze > requirements.txt' in the terminal to overwrite this file
 
-aioconsole
 fastapi
 uvicorn[standard]

--- a/snakem/config/client.py
+++ b/snakem/config/client.py
@@ -5,9 +5,6 @@ import curses.ascii
 SERVER_HOST: str = '127.0.0.1'
 SERVER_PORT: int = 9000
 
-# how fast to advance the game state
-STEP_TIME_MS: int = 100
-
 KEYS: dict = {
     'LOBBY_QUIT': [curses.ascii.ESC, ],
     'LOBBY_REFRESH': [ord('X'), ord('x'), ],

--- a/snakem/config/client.py
+++ b/snakem/config/client.py
@@ -3,21 +3,21 @@ import curses.ascii
 
 # the address of the main server to connect to
 SERVER_HOST: str = '127.0.0.1'
-SERVER_PORT: int = 11845
+SERVER_PORT: int = 9000
 
 # how fast to advance the game state
 STEP_TIME_MS: int = 100
 
-############ KEY BINDINGS ############
+KEYS: dict = {
+    'LOBBY_QUIT': [curses.ascii.ESC, ],
+    'LOBBY_REFRESH': [ord('X'), ord('x'), ],
+    'LOBBY_READY': [ord('R'), ord('r'), ],
+    #'LOBBY_1PLAYER': [ord('Y'), ord('y'), ],
 
-KEYS_LOBBY_QUIT: list[int] = [curses.ascii.ESC, ]
-KEYS_LOBBY_REFRESH: list[int] = [ord('X'), ord('x'), ]
-KEYS_LOBBY_READY: list[int] = [ord('R'), ord('r'), ]
-#KEYS_LOBBY_1PLAYER: list[int] = [ord('Y'), ord('y'), ]
+    'GAME_QUIT': [curses.ascii.ESC, ],
 
-KEYS_GAME_QUIT = [curses.ascii.ESC, ]
-
-KEYS_MV_UP: list[int] = [ord('W'), ord('w'), ord('K'), ord('k',), curses.KEY_UP, ]
-KEYS_MV_LEFT: list[int] = [ord('A'), ord('a'), ord('H'), ord('h'), curses.KEY_LEFT, ]
-KEYS_MV_DOWN: list[int] = [ord('S'), ord('s'), ord('J'), ord('j',), curses.KEY_DOWN, ]
-KEYS_MV_RIGHT: list[int] = [ord('D'), ord('d'), ord('L'), ord('l',), curses.KEY_RIGHT, ]
+    'MV_UP': [ord('W'), ord('w'), ord('K'), ord('k',), curses.KEY_UP, ],
+    'MV_LEFT': [ord('A'), ord('a'), ord('H'), ord('h'), curses.KEY_LEFT, ],
+    'MV_DOWN': [ord('S'), ord('s'), ord('J'), ord('j',), curses.KEY_DOWN, ],
+    'MV_RIGHT': [ord('D'), ord('d'), ord('L'), ord('l',), curses.KEY_RIGHT, ],
+}

--- a/snakem/config/server.py
+++ b/snakem/config/server.py
@@ -1,9 +1,3 @@
-# address = '' will bind to all interfaces
-BIND_ADDR: str = ''
-# port = 0 will use random port
-BIND_PORT_HEALTH_CHECK: int = 11844
-BIND_PORT: int = 11845
-
 # welcome message for new clients
 MOTD: str = 'Welcome to my Snake-M development server!'
 

--- a/snakem/game/display.py
+++ b/snakem/game/display.py
@@ -29,6 +29,8 @@ from .game import Game
 _last_debug_message: str = ''
 
 def show_message(scr: curses.window, msg: str) -> None:
+    logging.info(msg)
+
     erase(scr)
     height, width = get_window_size(scr)
     scr.addstr(height // 2, max(0, width // 2 - len(msg) // 2), msg)

--- a/snakem/game/enums.py
+++ b/snakem/game/enums.py
@@ -1,0 +1,34 @@
+# -*- coding: utf-8 -*-
+
+# *************************************************************************
+#
+#  This file is part of Snake-M.
+#
+#  Copyright © 2014 Mark Ross <krazkidd@gmail.com>
+#
+#  Snake-M is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Snake-M is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Snake-M.  If not, see <http://www.gnu.org/licenses/>.
+#
+# *************************************************************************
+
+from enum import Enum
+
+class Dir(Enum):
+    """An enum of the cardinal directions."""
+
+    #TODO use auto()?
+
+    UP = 0
+    DOWN = 1
+    LEFT = 2
+    RIGHT = 3

--- a/snakem/game/game.py
+++ b/snakem/game/game.py
@@ -33,7 +33,7 @@ class Game:
         self.height: int = height
 
         self.snakes: dict[int, Snake] = dict()
-        self.pellet: Pellet | None = None
+        self.pellet: Pellet
 
         self.tick_num: int = 0
 

--- a/snakem/game/game.py
+++ b/snakem/game/game.py
@@ -21,8 +21,6 @@
 #
 # *************************************************************************
 
-from collections import deque
-
 from .pellet import Pellet
 from .snake import Snake
 from .enums import Dir
@@ -94,7 +92,7 @@ class Game:
             else:
                 is_good_pos = True
 
-    def update_snake(self, snake_id: int, heading: Dir, is_alive: bool, body: deque[tuple[int, int]]) -> None:
+    def update_snake(self, snake_id: int, heading: Dir, is_alive: bool, body: list[tuple[int, int]]) -> None:
         if snake_id not in self.snakes:
             # just add the snake, I guess?
             self.spawn_new_snake(snake_id)

--- a/snakem/game/game.py
+++ b/snakem/game/game.py
@@ -37,6 +37,8 @@ class Game:
 
         self.tick_num: int = 0
 
+        self.spawn_new_pellet()
+
     def tick(self) -> None:
         # move all snakes before checking collisions
         for snake in self.snakes.values():

--- a/snakem/game/game.py
+++ b/snakem/game/game.py
@@ -25,7 +25,7 @@ from collections import deque
 
 from .pellet import Pellet
 from .snake import Snake
-from ..enums import Dir
+from .enums import Dir
 
 class Game:
     def __init__(self, width: int, height: int) -> None:
@@ -92,7 +92,7 @@ class Game:
             else:
                 is_good_pos = True
 
-    def update_snake(self, tick: int, snake_id: int, heading: Dir, is_alive: bool, body: deque[tuple[int, int]]) -> None:
+    def update_snake(self, snake_id: int, heading: Dir, is_alive: bool, body: deque[tuple[int, int]]) -> None:
         if snake_id not in self.snakes:
             # just add the snake, I guess?
             self.spawn_new_snake(snake_id)
@@ -102,7 +102,7 @@ class Game:
         snake.is_alive = is_alive
         snake.body = body
 
-    def update_pellet(self, tick: int, pellet_id: int, pos_x: int, pos_y: int) -> None:
+    def update_pellet(self, pellet_id: int, pos_x: int, pos_y: int) -> None:
         if not self.pellet:
             self.pellet = Pellet(1, 1, self.width - 1 - 1, self.height - 1 - 1)
 

--- a/snakem/game/snake.py
+++ b/snakem/game/snake.py
@@ -21,8 +21,6 @@
 #
 # *************************************************************************
 
-from collections import deque
-
 from .enums import Dir
 
 class Snake:
@@ -35,7 +33,7 @@ class Snake:
     """
 
     def __init__(self, head_pos: tuple[int, int], heading: Dir, length: int = 4) -> None:
-        self.body: deque[tuple[int, int]] = deque()
+        self.body: list[tuple[int, int]] = list()
 
         x_pos, y_pos = head_pos
         for i in range(length):
@@ -76,24 +74,28 @@ class Snake:
         """
 
         if self.is_alive:
+            if self.__should_grow:
+                self.body.append((-1, -1))
+
             x_pos, y_pos = self.body[0]
 
             # check the heading of the snake and move the
             # head's position accordingly
             if self.heading == Dir.RIGHT:
-                self.body.appendleft((x_pos + 1, y_pos))
+                x_pos = x_pos + 1
             elif self.heading == Dir.LEFT:
-                self.body.appendleft((x_pos - 1, y_pos))
+                x_pos = x_pos - 1
             elif self.heading == Dir.UP:
-                self.body.appendleft((x_pos, y_pos - 1))
+                y_pos = y_pos - 1
             elif self.heading == Dir.DOWN:
-                self.body.appendleft((x_pos, y_pos + 1))
+                y_pos = y_pos + 1
 
-            # pop the last body segment unless the snake is supposed to grow
-            if self.__should_grow:
-                self.__should_grow = False
-            else:
-                self.body.pop()
+            for i, pos_i in enumerate(self.body):
+                x_i, y_i = pos_i
+
+                self.body[i] = (x_pos, y_pos)
+
+                x_pos, y_pos = x_i, y_i
 
             if self.__next_heading:
                 self.heading = self.__next_heading

--- a/snakem/game/snake.py
+++ b/snakem/game/snake.py
@@ -23,7 +23,7 @@
 
 from collections import deque
 
-from ..enums import Dir
+from .enums import Dir
 
 class Snake:
 

--- a/snakem/net/client.py
+++ b/snakem/net/client.py
@@ -69,6 +69,8 @@ class Client:
                     await self._handle_game_message(ws, msg_type, json_dict)
                 else:
                     await self._handle_lobby_message(ws, msg_type, json_dict)
+
+                await asyncio.sleep(0)
         except ConnectionClosedOK:
             pass
         except ConnectionClosedError:

--- a/snakem/net/client.py
+++ b/snakem/net/client.py
@@ -74,9 +74,6 @@ class Client:
         except ConnectionClosedError:
             pass
         finally:
-            #TODO if the connection is still in an open state, send a quit message
-            #await ws.close(code=1000, reason=None)
-
             del self._socket
 
     async def start(self) -> None:
@@ -142,6 +139,9 @@ class Client:
     async def _handle_input(self, input_char: int) -> None:
         if self._game_state == GameState.LOBBY:
             if input_char in self._keys['LOBBY_QUIT']:
+                #TODO if the connection is still in an open state, send a quit message
+                #await self._socket.close(code=1000, reason=None)
+
                 sys.exit()
             elif input_char in self._keys['LOBBY_REFRESH']:
                 await net.send_lobby_join_request(self._socket)

--- a/snakem/net/client.py
+++ b/snakem/net/client.py
@@ -99,11 +99,11 @@ class Client:
                 now = time.monotonic_ns()
 
                 if (now - last_step_time) // 1_000_000 >= self._step_time_ms:
-                    last_step_time = now
-
                     self._game.tick()
 
                     display.show_game(self._stdscr, self._game)
+
+                    last_step_time = now
 
                 await asyncio.sleep(self._step_time_ms / 1000)
             else:

--- a/snakem/net/client.py
+++ b/snakem/net/client.py
@@ -21,146 +21,176 @@
 #
 # *************************************************************************
 
-import sys
+import asyncio
 import logging
-import socket
-import select
 import time
+import curses
+import os
+import sys
+
+from collections.abc import Awaitable
+from websockets.client import connect, WebSocketClientProtocol
+
+# must come after Awaitable
+import aioconsole
 
 from ..config import client as config
+from ..net import net
 from ..game import game, display
-from ..enums import GameState, MsgType, Dir
+from ..game.enums import Dir
 
-from . import net
+from .enums import GameState, MsgType
+from .server import app
 
 class Client:
-    def __init__(self) -> None:
-        self._poll = select.poll()
+    def __init__(self, ws: WebSocketClientProtocol, scr: curses.window, step_time_ms: int, keys: dict) -> None:
+        self._socket: WebSocketClientProtocol = ws
 
-        self._socket: socket.socket
+        self._stdscr: curses.window = scr
 
-        # the lobby server address
-        self._server_addr: tuple[str, int] = (config.SERVER_HOST, config.SERVER_PORT)
+        self._step_time_ms: int = step_time_ms
+        self._keys: dict = keys
 
         self._motd: str | None = None
         self._game_state: GameState = GameState.LOBBY
         self._game: game.Game
 
-    def start(self) -> None:
-        self._socket = net.init_client_socket()
+    async def start(self) -> Awaitable:
+        display.show_message(self._stdscr, 'Contacting server...')
 
-        self._poll.register(self._socket, select.POLLIN)
-        self._poll.register(sys.stdin, select.POLLIN)
-
-        logging.info('Contacting %s on port %s.', config.SERVER_HOST, config.SERVER_PORT)
-
-        net.send_hello_message(self._socket, self._server_addr)
-        net.send_lobby_join_request(self._socket, self._server_addr)
-
-        #TODO don't pass self._start_with_curses method as a delegate (use an interface)
-        display.init_client_window(self._start_with_curses)
-
-    def _start_with_curses(self) -> None:
-        display.show_message(f'Contacting server at {config.SERVER_HOST}:{config.SERVER_PORT} . . .')
+        # contact the server immediately
+        # async with asyncio.TaskGroup() as tg:
+        #     task1 = tg.create_task(net.send_hello_message(self._socket))
+        #     task2 = tg.create_task(net.send_lobby_join_request(self._socket))
+        await net.send_hello_message(self._socket)
+        await net.send_lobby_join_request(self._socket)
 
         last_step_time = time.monotonic_ns()
 
         try:
             while 1:
-                if self._game_state == GameState.GAME:
-                    inputs = self._poll.poll(net.TIMEOUT)
+                done, pending = await asyncio.wait([
+                    asyncio.create_task(aioconsole.ainput(), name='stdin'),
+                    asyncio.create_task(net.receive_message(self._socket), name='ws')
+                ], return_when=asyncio.FIRST_COMPLETED)
+
+                #TODO handle *all* net messages first before checking input?
+
+                input_char = display.get_key(self._stdscr)
+                if input_char != curses.ERR:
+                    await self._handle_input(input_char)
                 else:
-                    # we block on this call so we're not wasting cycles outside of an active game
-                    inputs = self._poll.poll()
+                    #TODO is this right?
+                    ws, msg_type, json = await net.receive_message(self._socket)
 
-                for fd, event in inputs:
-                    if fd == sys.stdin.fileno():
-                        self._handle_input(display.get_key())
-                    elif fd == self._socket.fileno():
-                        address, msg_type, msg_body = net.receive_message(self._socket)
-
-                        if self._game_state == GameState.GAME:
-                            self._handle_game_message(address, msg_type, msg_body)
-                        else:
-                            self._handle_lobby_message(address, msg_type, msg_body)
+                    if self._game_state == GameState.GAME:
+                        self._handle_game_message(msg_type, json)
+                    else:
+                        self._handle_lobby_message(msg_type, json)
 
                 if self._game_state == GameState.GAME:
                     now = time.monotonic_ns()
 
                     #TODO get STEP_TIME_MS from server during game setup
-                    if (now - last_step_time) // 1_000_000 >= config.STEP_TIME_MS:
+                    if (now - last_step_time) // 1_000_000 >= self._step_time_ms:
                         last_step_time = now
 
-                        display.show_game(self._game)
+                        display.show_game(self._stdscr, self._game)
         finally:
-            if self._server_addr:
-                net.send_quit_message(self._socket, self._server_addr)
+            await net.send_quit_message(self._socket)
             self._socket.close()
 
-    def _handle_lobby_message(self, address: tuple[str, int], msg_type: MsgType, msg_body: bytes) -> None:
+    async def _poll_for_input(self) -> int:
+        return self._stdscr.getch();
+
+    def _handle_lobby_message(self, msg_type: MsgType, json: dict) -> None:
         if msg_type == MsgType.LOBBY_JOIN:
             self._start_lobby_mode()
         elif msg_type == MsgType.LOBBY_QUIT:
-            display.show_debug('Lobby rejected your join request.')
+            display.show_debug(self._stdscr, 'Lobby rejected your join request.')
             self._start_lobby_mode()
         elif msg_type == MsgType.START:
-            width, height = net.unpack_start_message(msg_body)
+            width, height = net.unpack_start_message(json)
 
             self._start_game_mode(width, height)
         elif msg_type == MsgType.MOTD:
-            self._motd = bytes.decode(msg_body)
+            self._motd = json['motd']
 
             self._start_lobby_mode()
 
-    def _handle_game_message(self, address: tuple[str, int], msg_type: MsgType, msg_body: bytes) -> None:
+    def _handle_game_message(self, msg_type: MsgType, msg_body: dict) -> None:
         if msg_type == MsgType.SNAKE_UPDATE:
+            #TODO use tick value to determine if it's safe to update game state
+            #     or if it's out of date (compare to current game tick value)
             tick, snake_id, heading, is_alive, body = net.unpack_snake_update(msg_body)
 
-            self._game.update_snake(tick, snake_id, heading, is_alive, body)
+            self._game.update_snake(snake_id, heading, is_alive, body)
         elif msg_type == MsgType.PELLET_UPDATE:
+            #TODO use tick value to determine if it's safe to update game state
+            #     or if it's out of date (compare to current game tick value)
             tick, pellet_id, pos_x, pos_y = net.unpack_pellet_update(msg_body)
 
-            self._game.update_pellet(tick, pellet_id, pos_x, pos_y)
+            self._game.update_pellet(pellet_id, pos_x, pos_y)
         elif msg_type == MsgType.LOBBY_JOIN:
             self._start_lobby_mode()
 
-    def _handle_input(self, input_char: int) -> None:
+    async def _handle_input(self, input_char: int) -> None:
         if self._game_state == GameState.LOBBY:
-            if input_char in config.KEYS_LOBBY_QUIT:
+            if input_char in self._keys['LOBBY_QUIT']:
                 sys.exit()
-            elif input_char in config.KEYS_LOBBY_REFRESH:
-                net.send_hello_message(self._socket, self._server_addr)
-                net.send_lobby_join_request(self._socket, self._server_addr)
-            elif input_char in config.KEYS_LOBBY_READY:
-                net.send_ready_message(self._socket, self._server_addr)
+            elif input_char in self._keys['LOBBY_REFRESH']:
+                await asyncio.wait([
+                    net.send_hello_message(self._socket),
+                    net.send_lobby_join_request(self._socket)
+                ])
+            elif input_char in self._keys['LOBBY_READY']:
+                await net.send_ready_message(self._socket)
         elif self._game_state == GameState.GAME:
-            if input_char in config.KEYS_GAME_QUIT:
+            if input_char in self._keys['GAME_QUIT']:
                 #TODO make it harder to quit running game
-                net.send_quit_message(self._socket, self._server_addr)
+                await net.send_quit_message(self._socket)
                 self._start_lobby_mode()
-            elif input_char in config.KEYS_MV_LEFT:
-                net.send_input_message(self._socket, self._server_addr, Dir.LEFT)
-            elif input_char in config.KEYS_MV_DOWN:
-                net.send_input_message(self._socket, self._server_addr, Dir.DOWN)
-            elif input_char in config.KEYS_MV_UP:
-                net.send_input_message(self._socket, self._server_addr, Dir.UP)
-            elif input_char in config.KEYS_MV_RIGHT:
-                net.send_input_message(self._socket, self._server_addr, Dir.RIGHT)
+            elif input_char in self._keys['MV_LEFT']:
+                await net.send_input_message(self._socket, self._game.tick_num, Dir.LEFT)
+            elif input_char in self._keys['MV_DOWN']:
+                await net.send_input_message(self._socket, self._game.tick_num, Dir.DOWN)
+            elif input_char in self._keys['MV_UP']:
+                await net.send_input_message(self._socket, self._game.tick_num, Dir.UP)
+            elif input_char in self._keys['MV_RIGHT']:
+                await net.send_input_message(self._socket, self._game.tick_num, Dir.RIGHT)
 
     def _start_lobby_mode(self) -> None:
         self._game_state = GameState.LOBBY
 
-        display.show_lobby(self._motd)
+        display.show_lobby(self._stdscr, self._motd)
 
     def _start_game_mode(self, width: int, height: int) -> None:
         self._game_state = GameState.GAME
 
         self._game = game.Game(width, height)
 
-        display.show_game(self._game)
+        display.show_game(self._stdscr, self._game)
 
 if __name__ == '__main__':
     #TODO add timestamp (with format)
-    #logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
+    #logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
 
-    Client().start()
+    # set shorter delay for ESC key recognition
+    if 'ESCDELAY' not in os.environ:
+        os.environ.setdefault('ESCDELAY', '75')
+
+    def start_with_curses(scr: curses.window) -> None:
+        # scr.getch() will return immediately (-1 if no input)
+        # see: https://docs.python.org/3/library/curses.html#curses.window.getch
+        scr.nodelay(True)
+
+        async def main() -> None:
+            #TODO provide client_id to reconnect (save to file?)
+            async with connect(f'ws://{config.SERVER_HOST}:{config.SERVER_PORT}/ws') as ws:
+                await Client(ws, scr, config.STEP_TIME_MS, config.KEYS).start()
+
+        asyncio.run(main())
+
+    # cbreak on, echo off, keypad on, colors on
+    curses.wrapper(start_with_curses)

--- a/snakem/net/client.py
+++ b/snakem/net/client.py
@@ -184,9 +184,6 @@ class Client:
 
         display.show_game(self._stdscr, self._game)
 
-_client: Client
-_client_task: asyncio.Task
-
 if __name__ == '__main__':
     #TODO add timestamp (with format)
     #logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
@@ -202,12 +199,12 @@ if __name__ == '__main__':
         scr.nodelay(True)
 
         async def main() -> None:
-            global _client, _client_task
-            _client = Client(scr, config.KEYS)
-            _client_task = asyncio.create_task(_client.start())
+            client = Client(scr, config.KEYS)
+
+            asyncio.create_task(client.start())
 
             async with connect(f'ws://{config.SERVER_HOST}:{config.SERVER_PORT}/ws') as ws:
-                await _client.connect_client(ws)
+                await client.connect_client(ws)
 
         asyncio.run(main())
 

--- a/snakem/net/enums.py
+++ b/snakem/net/enums.py
@@ -23,56 +23,11 @@
 
 from enum import Enum
 
-class Dir(Enum):
-    """An enum of the cardinal directions."""
-
-    #TODO use auto()?
-
-    UP = 0
-    DOWN = 1
-    LEFT = 2
-    RIGHT = 3
-
 class GameState(Enum):
     #TODO use auto()?
 
     LOBBY = 0
     GAME = 1
-
-class MsgFmt:
-    # net message header
-    # B: message type
-    # H: length of message (including header)
-    HDR = '!BH'
-
-    # start message
-    # i: window width
-    # i: window height
-    START = '!ii'
-
-    # snake update message (header)
-    # I: tick num (game time elapsed)
-    # i: snake ID
-    # B: heading
-    # ?: is alive
-    # I: body length
-    SNAKE_UPDATE_HDR = '!IiB?I'
-
-    # snake update message (snake body)
-    # i: x position
-    # i: y position
-    SNAKE_UPDATE_BDY = '!ii'
-
-    # pellet update message
-    # I: tick num (game time elapsed)
-    # i: pellet ID
-    # i: x position
-    # i: y position
-    PELLET_UPDATE = '!Iiii'
-
-    # client/player input
-    # B: new heading
-    PLAYER_INPUT = '!B'
 
 class MsgType(Enum):
     """Enum for Snake network messages"""

--- a/snakem/net/net.py
+++ b/snakem/net/net.py
@@ -24,8 +24,6 @@
 import json
 import logging
 
-from collections import deque
-
 from starlette.websockets import WebSocket # aka fastapi.WebSocket
 from websockets.client import WebSocketClientProtocol
 
@@ -95,13 +93,8 @@ async def send_snake_update(ws: WebSocketClientProtocol | WebSocket, tick: int, 
         'body': snake.body
     })
 
-def unpack_snake_update(json_dict: dict) -> tuple[int, int, Dir, bool, deque[tuple[int, int]]]:
-    #TODO get the body
-    body: deque[tuple[int, int]] = deque()
-    for pos_x, pos_y in body:
-        body.append((pos_x, pos_y))
-
-    return json_dict['tick'], json_dict['snake_id'], Dir(json_dict['heading']), json_dict['is_alive'] == 'true', body
+def unpack_snake_update(json_dict: dict) -> tuple[int, int, Dir, bool, list[tuple[int, int]]]:
+    return json_dict['tick'], json_dict['snake_id'], Dir(json_dict['heading']), json_dict['is_alive'] == 'true', json_dict['body']
 
 async def send_lobby_join_request(ws: WebSocketClientProtocol | WebSocket) -> None:
     await send_message(ws, MsgType.LOBBY_JOIN)

--- a/snakem/net/net.py
+++ b/snakem/net/net.py
@@ -25,10 +25,9 @@ import json
 import logging
 
 from collections import deque
-from collections.abc import Awaitable
 
+from starlette.websockets import WebSocket # aka fastapi.WebSocket
 from websockets.client import WebSocketClientProtocol
-from fastapi import WebSocket
 
 from ..game.enums import Dir
 from ..game.pellet import Pellet
@@ -39,56 +38,55 @@ from .enums import MsgType
 # how long to wait for a network message or other input event
 TIMEOUT: float = 0.005
 
-async def _send_message(ws: WebSocketClientProtocol | WebSocket, msg_type: MsgType, jsonDict: dict | None = None) -> Awaitable:
-    if jsonDict is None:
-        jsonDict = { '_msg_type': msg_type.value }
+async def send_message(ws: WebSocketClientProtocol | WebSocket, msg_type: MsgType, json_dict: dict | None = None) -> None:
+    if json_dict is None:
+        json_dict = { '_msg_type': msg_type.value }
     else:
-        jsonDict['_msg_type'] = msg_type.value
+        json_dict['_msg_type'] = msg_type.value
 
     logging.debug('NETMSG (to %s): <%s>', 'TODO', msg_type.name)
 
     if isinstance(ws, WebSocketClientProtocol):
-        return await ws.send(json.dumps(jsonDict))
+        await ws.send(json.dumps(json_dict))
     else:
-        return await ws.send_json(jsonDict)
+        await ws.send_json(json_dict)
 
-async def receive_message(ws: WebSocketClientProtocol | WebSocket) -> Awaitable[tuple[MsgType, dict]]:
+async def receive_message(ws: WebSocketClientProtocol | WebSocket) -> tuple[MsgType, dict]:
+    json_dict: dict
+
     if isinstance(ws, WebSocketClientProtocol):
-        jsonDict = json.loads(await ws.recv())
+        json_dict = json.loads(await ws.recv())
     else:
-        jsonDict = await ws.receive_json()
+        json_dict = await ws.receive_json()
 
-    msg_type = MsgType(jsonDict['_msg_type'])
+    msg_type = MsgType(json_dict['_msg_type'])
 
     #TODO print address as first argument
     logging.debug('NETMSG (from %s): <%s>', 'TODO', msg_type.name)
 
-    return ws, msg_type, jsonDict
+    return msg_type, json_dict
 
-async def send_hello_message(ws: WebSocketClientProtocol | WebSocket) -> Awaitable:
-    return await _send_message(ws, MsgType.MOTD)
-
-async def send_motd(ws: WebSocketClientProtocol | WebSocket, motd: str) -> Awaitable:
-    return await _send_message(ws, MsgType.MOTD, {
+async def send_motd(ws: WebSocketClientProtocol | WebSocket, motd: str) -> None:
+    await send_message(ws, MsgType.MOTD, {
         'motd': motd
     })
 
-async def send_quit_message(ws: WebSocketClientProtocol | WebSocket) -> Awaitable:
-    return await _send_message(ws, MsgType.LOBBY_QUIT)
+async def send_quit_message(ws: WebSocketClientProtocol | WebSocket) -> None:
+    await send_message(ws, MsgType.LOBBY_QUIT)
 
-async def send_pellet_update(ws: WebSocketClientProtocol | WebSocket, tick: int, pellet_id: int, pellet: Pellet) -> Awaitable:
-    return await _send_message(ws, MsgType.PELLET_UPDATE, {
+async def send_pellet_update(ws: WebSocketClientProtocol | WebSocket, tick: int, pellet_id: int, pellet: Pellet) -> None:
+    await send_message(ws, MsgType.PELLET_UPDATE, {
         'tick': tick,
         'pellet_id': pellet_id,
         'pos_x': pellet.pos[0],
         'pos_y': pellet.pos[1]
     })
 
-def unpack_pellet_update(jsonDict: dict) -> tuple[int, int, int, int]:
-    return jsonDict['tick'], jsonDict['pellet_id'], jsonDict['pos_x'], jsonDict['pos_y']
+def unpack_pellet_update(json_dict: dict) -> tuple[int, int, int, int]:
+    return json_dict['tick'], json_dict['pellet_id'], json_dict['pos_x'], json_dict['pos_y']
 
-async def send_snake_update(ws: WebSocketClientProtocol | WebSocket, tick: int, snake_id: int, snake: Snake) -> Awaitable:
-    return await _send_message(ws, MsgType.SNAKE_UPDATE, {
+async def send_snake_update(ws: WebSocketClientProtocol | WebSocket, tick: int, snake_id: int, snake: Snake) -> None:
+    await send_message(ws, MsgType.SNAKE_UPDATE, {
         'tick': tick,
         'snake_id': snake_id,
         'heading': snake.heading.value,
@@ -97,34 +95,35 @@ async def send_snake_update(ws: WebSocketClientProtocol | WebSocket, tick: int, 
         'body': snake.body
     })
 
-def unpack_snake_update(jsonDict: dict) -> tuple[int, int, Dir, bool, deque[tuple[int, int]]]:
+def unpack_snake_update(json_dict: dict) -> tuple[int, int, Dir, bool, deque[tuple[int, int]]]:
     #TODO get the body
     body: deque[tuple[int, int]] = deque()
     for pos_x, pos_y in body:
         body.append((pos_x, pos_y))
 
-    return jsonDict['tick'], jsonDict['snake_id'], Dir(jsonDict['heading']), jsonDict['is_alive'] == 'true', body
+    return json_dict['tick'], json_dict['snake_id'], Dir(json_dict['heading']), json_dict['is_alive'] == 'true', body
 
-async def send_lobby_join_request(ws: WebSocketClientProtocol | WebSocket) -> Awaitable:
-    return await _send_message(ws, MsgType.LOBBY_JOIN)
+async def send_lobby_join_request(ws: WebSocketClientProtocol | WebSocket) -> None:
+    await send_message(ws, MsgType.LOBBY_JOIN)
 
-async def send_ready_message(ws: WebSocketClientProtocol | WebSocket) -> Awaitable:
-    return await _send_message(ws, MsgType.READY)
+async def send_ready_message(ws: WebSocketClientProtocol | WebSocket) -> None:
+    await send_message(ws, MsgType.READY)
 
-async def send_start_message(ws: WebSocketClientProtocol | WebSocket, width: int, height: int) -> Awaitable:
-    return await _send_message(ws, MsgType.START, {
+async def send_start_message(ws: WebSocketClientProtocol | WebSocket, width: int, height: int, step_time_ms: int) -> None:
+    await send_message(ws, MsgType.START, {
         'width': width,
-        'height': height
+        'height': height,
+        'step_time_ms': step_time_ms
     })
 
-def unpack_start_message(jsonDict: dict) -> tuple[int, int]:
-    return jsonDict['width'], jsonDict['height']
+def unpack_start_message(json_dict: dict) -> tuple[int, int, int]:
+    return json_dict['width'], json_dict['height'], json_dict['step_time_ms']
 
-async def send_input_message(ws: WebSocketClientProtocol | WebSocket, tick: int, heading: Dir) -> Awaitable:
-    return await _send_message(ws, MsgType.INPUT, {
+async def send_input_message(ws: WebSocketClientProtocol | WebSocket, tick: int, heading: Dir) -> None:
+    await send_message(ws, MsgType.INPUT, {
         'tick': tick,
         'heading': heading.value
     })
 
-def unpack_input_message(jsonDict: dict) -> tuple[int, Dir]:
-    return jsonDict['tick'], Dir(jsonDict['heading'])
+def unpack_input_message(json_dict: dict) -> tuple[int, Dir]:
+    return json_dict['tick'], Dir(json_dict['heading'])

--- a/snakem/net/server.py
+++ b/snakem/net/server.py
@@ -153,6 +153,7 @@ class Server:
             self._players[ws] = (player_tuple[0], self._game.spawn_new_snake())
 
         #TODO send snake and pellet statuses with start message
+        #     and get rid of this double loop
 
         for ws in self._players:
             await net.send_pellet_update(ws, self._game.tick_num, 0, self._game.pellet)

--- a/snakem/net/server.py
+++ b/snakem/net/server.py
@@ -48,10 +48,6 @@ class Server:
         self._game: game.Game
 
     async def connect_client(self, ws: WebSocket) -> None:
-        #TODO accessing self._players needs thread safety if we are going to multithread
-
-        self._players[ws] = (MsgType.NOT_READY, None)
-
         try:
             await net.send_motd(ws, self._motd)
 
@@ -68,9 +64,6 @@ class Server:
         except WebSocketDisconnect:
             pass
         finally:
-            #TODO if the connection is still in an open state, send a quit message
-            #await websocket.close(code=1000, reason=None)
-
             del self._players[ws]
 
     async def start(self) -> None:
@@ -113,6 +106,9 @@ class Server:
                 await net.send_lobby_join_request(ws)  # LOBBY_JOIN is used for join confirmation
                 self._players[ws] = (MsgType.NOT_READY, snake_id)  # reset READY status
             elif msg_type == MsgType.LOBBY_QUIT:
+                #TODO if the connection is still in an open state, send a quit message
+                #await websocket.close(code=1000, reason=None)
+
                 del self._players[ws]
             elif msg_type == MsgType.READY:
                 self._players[ws] = (MsgType.READY, snake_id)

--- a/snakem/net/server.py
+++ b/snakem/net/server.py
@@ -21,77 +21,99 @@
 #
 # *************************************************************************
 
+import asyncio
 import logging
-import socket
-import select
 import time
 
-from ..config import server as config
-from ..game import game
-from ..enums import GameState, MsgType
+from typing import Any
 
-from . import net
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+
+from ..config import server as config
+from ..net import net
+from ..game import game
+
+from .enums import GameState, MsgType
+
+app = FastAPI()
+
+@app.get("/api/health")
+async def api_health():
+    return {"status": "alive"}
+
+@app.websocket("/ws")
+#@app.websocket("/ws/")
+#@app.websocket("/ws/{client_id}")
+async def websocket_endpoint(ws: WebSocket, client_id: int | None = None):
+    #TODO if client_id != None, then we should not accept() and hand them off to the server
+
+    await ws.accept()
+
+    try:
+        while 1:
+            await asyncio.sleep(1)
+            await net.send_motd(ws, config.MOTD)
+            # await manager.send_personal_message(f"You wrote: {data}", ws)
+            # await manager.broadcast(f"Client #{client_id} says: {data}")
+    except WebSocketDisconnect:
+        # manager.disconnect(ws)
+        # await manager.broadcast(f"Client #{client_id} left the chat")
+        pass
 
 class Server:
-    def __init__(self) -> None:
-        self._health_check_socket: socket.socket
-        self._socket: socket.socket
+    def __init__(self, width: int, height: int, step_time_ms: int) -> None:
+        self._width: int = width
+        self._height: int = height
+        self._step_time_ms: int = step_time_ms
 
-        self._poll = select.poll()
-
-        # self.active_players maps net addresses to tuples of (r, s) where:
+        # self.active_players maps websockets to tuples of (r, s) where:
         #   r = ready status (MsgType.{NOT_,}READY)
         #   s = snake id when a game is running
-        self._players: dict[tuple[str, int], tuple[MsgType, int | None]] = dict()
+        self._players: dict[WebSocket, tuple[MsgType, int | None]] = dict()
 
         self._game_state: GameState = GameState.LOBBY
         self._game: game.Game
 
-    def start(self) -> None:
-        self._health_check_socket = net.init_health_check_socket((config.BIND_ADDR, config.BIND_PORT_HEALTH_CHECK))
-        self._socket = net.init_server_socket((config.BIND_ADDR, config.BIND_PORT))
-
-        self._poll.register(self._health_check_socket, select.POLLIN)
-        self._poll.register(self._socket, select.POLLIN)
-
-        logging.info('Health check listening on port %s.', config.BIND_PORT_HEALTH_CHECK)
-        logging.info('Server listening on port %s.', config.BIND_PORT)
+    async def start(self) -> Any: # Awaitable
+        logging.info('Server started.')
 
         last_step_time = time.monotonic_ns()
 
         try:
             while 1:
-                if self._game_state == GameState.GAME:
-                    inputs = self._poll.poll(net.TIMEOUT)
-                else:
-                    # we block on this call so we're not wasting cycles outside of an active game
-                    inputs = self._poll.poll()
+                #TODO handle disconnects by handling WebSocketDisconnect exception
+                # try:
+                #     while 1:
+                #         data = await websocket.receive_text()
+                #         # await manager.send_personal_message(f"You wrote: {data}", websocket)
+                #         # await manager.broadcast(f"Client #{client_id} says: {data}")
+                # except WebSocketDisconnect:
+                #     websocket.disconnect(websocket)
+                #     await websocket.broadcast(f"Client #{client_id} left the chat")
 
-                for fd, event in inputs:
-                    if fd == self._health_check_socket.fileno():
-                        conn, addr = self._health_check_socket.accept()
-                        conn.shutdown(socket.SHUT_RDWR)
-                        conn.close()
-                    elif fd == self._socket.fileno():
-                        address, msg_type, msg_body = net.receive_message(self._socket)
+                done, _ = await asyncio.wait([net.receive_message(ws) for ws in self._players.keys], return_when=asyncio.FIRST_COMPLETED)
 
-                        if self._game_state == GameState.GAME:
-                            self._handle_game_message(address, msg_type, msg_body)
-                        else:
-                            self._handle_lobby_message(address, msg_type, msg_body)
+                #TODO do i need to cancel pending tasks?
+                #TODO do i need to cancel done tasks if i don't consume them?
+
+                for awaitable in done:
+                    ws, msg_type, json = await awaitable
+
+                    if self._game_state == GameState.GAME:
+                        await self._handle_game_message(ws, msg_type, json)
+                    else:
+                        await self._handle_lobby_message(ws, msg_type, json)
 
                 if self._game_state == GameState.GAME:
                     now = time.monotonic_ns()
 
-                    if (now - last_step_time) // 1_000_000 >= config.STEP_TIME_MS:
+                    if (now - last_step_time) // 1_000_000 >= self._step_time_ms:
                         last_step_time = now
 
                         self._game.tick()
 
-                        for addr in self._players:
-                            for snake_id, snake in self._game.snakes.items():
-                                logging.debug('(%s, %s)', snake.body[0][0], snake.body[0][1])
-                                net.send_snake_update(self._socket, addr, self._game.tick_num, snake_id, snake)
+                        # update all players with all snakes
+                        await asyncio.wait([net.send_snake_update(ws, self._game.tick_num, snake_id, snake) for ws in self._players for snake_id, snake in self._game.snakes.items()])
 
                         # end game when all snakes are dead
                         #TODO the game should end when at most *one* snake is alive
@@ -99,83 +121,79 @@ class Server:
                             if snake.is_alive:
                                 break
                         else:
-                            for addr in self._players:
-                                net.send_lobby_join_request(self._socket, addr)
+                            await asyncio.wait([net.send_lobby_join_request(ws) for ws in self._players])
 
                             self._start_lobby_mode()
         except Exception:
             logging.exception('Unknown exception.')
-        finally:
-            self._health_check_socket.close()
-            self._socket.close()
 
-    def _handle_lobby_message(self, address: tuple[str, int], msg_type: MsgType, msg_body: bytes) -> None:
-        if address in self._players:
-            status, snake_id = self._players[address]
+    async def _handle_lobby_message(self, ws: WebSocket, msg_type: MsgType, json: dict) -> None:
+        if ws in self._players:
+            _, snake_id = self._players[ws]
 
             if msg_type == MsgType.LOBBY_JOIN:
-                net.send_lobby_join_request(self._socket, address)  # LOBBY_JOIN is used for join confirmation
-                self._players[address] = (MsgType.NOT_READY, snake_id)  # reset READY status
+                await net.send_lobby_join_request(ws)  # LOBBY_JOIN is used for join confirmation
+                self._players[ws] = (MsgType.NOT_READY, snake_id)  # reset READY status
             elif msg_type == MsgType.LOBBY_QUIT:
-                del self._players[address]
+                del self._players[ws]
             elif msg_type == MsgType.READY:
-                self._players[address] = (MsgType.READY, snake_id)
+                self._players[ws] = (MsgType.READY, snake_id)
 
-                for addr, player_tuple in self._players.items():
+                for player_tuple in self._players.values():
                     if player_tuple[0] != MsgType.READY:
                         break
                 else:
-                    self._start_game_mode(config.WIN_WIDTH, config.WIN_HEIGHT)
+                    await self._start_game_mode(self._width, self._height)
             elif msg_type == MsgType.NOT_READY:
-                self._players[address] = (MsgType.NOT_READY, snake_id)
+                self._players[ws] = (MsgType.NOT_READY, snake_id)
         else:
             if msg_type == MsgType.LOBBY_JOIN:
                 if len(self._players) < 4:
-                    net.send_lobby_join_request(self._socket, address)  # LOBBY_JOIN is used for join confirmation
-                    self._players[address] = (MsgType.NOT_READY, None)
+                    await net.send_lobby_join_request(ws)  # LOBBY_JOIN is used for join confirmation
+                    self._players[ws] = (MsgType.NOT_READY, None)
                 else:
-                    net.send_quit_message(self._socket, address)  # LOBBY_QUIT is used for join rejection
+                    await net.send_quit_message(ws)  # LOBBY_QUIT is used for join rejection
 
-    def _handle_game_message(self, address: tuple[str, int], msg_type: MsgType, msg_body: bytes) -> None:
-        if address in self._players:
+    async def _handle_game_message(self, ws: WebSocket, msg_type: MsgType, json: dict) -> None:
+        if ws in self._players:
             do_update_clients = False
 
             if msg_type == MsgType.INPUT:
-                self._game.snakes[self._players[address][1]].change_heading(net.unpack_input_message(msg_body)) # type: ignore
+                self._game.snakes[self._players[ws][1]].change_heading(net.unpack_input_message(json)) # type: ignore
                 do_update_clients = True
 
             if do_update_clients:
-                for addr in self._players:
-                    net.send_pellet_update(self._socket, addr, self._game.tick_num, 0, self._game.pellet)
+                for sock in self._players:
+                    await net.send_pellet_update(sock, self._game.tick_num, 0, self._game.pellet)
 
                     for snake_id, snake in self._game.snakes.items():
-                        net.send_snake_update(self._socket, addr, self._game.tick_num, snake_id, snake)
+                        await net.send_snake_update(sock, self._game.tick_num, snake_id, snake)
 
     def _start_lobby_mode(self) -> None:
         self._game_state = GameState.LOBBY
 
-    def _start_game_mode(self, width: int, height: int) -> None:
+    async def _start_game_mode(self, width: int, height: int) -> None:
         self._game_state = GameState.GAME
 
         self._game = game.Game(width, height)
 
-        for addr, player_tuple in self._players.items():
+        for ws, player_tuple in self._players.items():
             self._players[addr] = (player_tuple[0], self._game.spawn_new_snake())
 
         self._game.spawn_new_pellet()
 
-        for addr in self._players:
-            net.send_pellet_update(self._socket, addr, self._game.tick_num, 0, self._game.pellet)
+        for ws in self._players:
+            await net.send_pellet_update(ws, self._game.tick_num, 0, self._game.pellet)
 
             for snake_id, snake in self._game.snakes.items():
-                net.send_snake_update(self._socket, addr, self._game.tick_num, snake_id, snake)
+                await net.send_snake_update(ws, self._game.tick_num, snake_id, snake)
 
         for addr in self._players:
-            net.send_start_message(self._socket, addr, self._game.width, self._game.height)
+            await net.send_start_message(ws, self._game.width, self._game.height)
 
 if __name__ == '__main__':
     #TODO add timestamp (with format)
     #logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.INFO)
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=logging.DEBUG)
 
-    Server().start()
+    #TODO Server(config.WIN_WIDTH, config.WIN_HEIGHT, config.STEP_TIME_MS).start()

--- a/snakem/net/server.py
+++ b/snakem/net/server.py
@@ -83,8 +83,6 @@ class Server:
                 now = time.monotonic_ns()
 
                 if (now - last_step_time) // 1_000_000 >= self._step_time_ms:
-                    last_step_time = now
-
                     self._game.tick()
 
                     #TODO uncomment
@@ -100,6 +98,8 @@ class Server:
                         #TODO consider returning from this and letting the thread end
 
                         await self._start_lobby_mode()
+
+                    last_step_time = now
 
                 await asyncio.sleep(self._step_time_ms / 1000)
             else:

--- a/snakem/web/app.py
+++ b/snakem/web/app.py
@@ -1,0 +1,21 @@
+from fastapi import FastAPI
+from fastapi.responses import RedirectResponse
+
+from .routers import api, view, ws
+
+app = FastAPI()
+
+app.include_router(api.router)
+app.include_router(ws.router)
+
+app.include_router(view.router)
+
+@app.get("/", response_class=RedirectResponse)
+async def view_root():
+    return '/view'
+
+if __name__ == '__main__':
+    import uvicorn
+
+    #TODO get arguments from env/cli
+    uvicorn.run('app:app', host='127.0.0.1', port=9000, reload=False, log_level='debug')

--- a/snakem/web/routers/api.py
+++ b/snakem/web/routers/api.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+
+# *************************************************************************
+#
+#  This file is part of Snake-M.
+#
+#  Copyright © 2014 Mark Ross <krazkidd@gmail.com>
+#
+#  Snake-M is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Snake-M is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Snake-M.  If not, see <http://www.gnu.org/licenses/>.
+#
+# *************************************************************************
+
+from fastapi import APIRouter
+
+router = APIRouter(
+    prefix="/api",
+    tags=["api"],
+    #dependencies=[Depends(...)],
+    responses={404: {"description": "Not found"}},
+)
+
+@router.get("/health")
+async def api_health():
+    #TODO return a health status object and document the type in the decorator (for reusability)
+    return {"status": "alive"}

--- a/snakem/web/routers/view.py
+++ b/snakem/web/routers/view.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+
+# *************************************************************************
+#
+#  This file is part of Snake-M.
+#
+#  Copyright © 2014 Mark Ross <krazkidd@gmail.com>
+#
+#  Snake-M is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Snake-M is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Snake-M.  If not, see <http://www.gnu.org/licenses/>.
+#
+# *************************************************************************
+
+from fastapi import APIRouter
+from fastapi.responses import HTMLResponse
+
+from ...config import server
+
+router = APIRouter(
+    prefix="/view",
+    tags=["view"],
+    #dependencies=[Depends(...)],
+    responses={404: {"description": "Not found"}},
+)
+
+@router.get("", response_class=HTMLResponse)
+async def view_root():
+    return f'<html><head><title></title></head><body>{server.MOTD}</body></html>'

--- a/snakem/web/routers/ws.py
+++ b/snakem/web/routers/ws.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+
+# *************************************************************************
+#
+#  This file is part of Snake-M.
+#
+#  Copyright © 2014 Mark Ross <krazkidd@gmail.com>
+#
+#  Snake-M is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  Snake-M is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with Snake-M.  If not, see <http://www.gnu.org/licenses/>.
+#
+# *************************************************************************
+
+import asyncio
+
+from starlette.websockets import WebSocket # aka fastapi.{WebSocket, WebSocketDisconnect}
+from fastapi import APIRouter
+
+from ...config import server as config
+from ...net import server
+
+_server = None # type: server.Server
+_server_task = None # type: asyncio.Task
+
+router = APIRouter(
+    prefix="/ws",
+    tags=["websockets"],
+    #dependencies=[Depends(...)],
+    responses={404: {"description": "Not found"}},
+)
+
+@router.websocket("")
+async def ws_root(ws: WebSocket):
+    global _server, _server_task
+    if not _server:
+        _server = server.Server(config.MOTD, config.WIN_WIDTH, config.WIN_HEIGHT, config.STEP_TIME_MS)
+        _server_task = asyncio.create_task(_server.start())
+
+    await ws.accept()
+
+    await _server.connect_client(ws)


### PR DESCRIPTION
Major rewrite with WebSockets rather than POSIX sockets and FastAPI (for exposing web endpoints).

Because FastAPI and the websockets module (optionally) are asynchronous APIs, implement async/await wherever possible to take advantage.

On server side, run game in own thread so we can return control to FastAPI. On client side, run game in own thread in order to work around issues with polling for keyboard and network input.

This implementation may be a bit unstable with regard to thread safety. Additionally, all kinds of unhandled exceptions are thrown when trying to exit the game. These should get cleaned up later.